### PR TITLE
move Retry code to its own method for Hooking purposes

### DIFF
--- a/EasyRetry/EasyRetry.csproj
+++ b/EasyRetry/EasyRetry.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -46,16 +46,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Celeste">
-      <HintPath>..\..\..\..\.steam\steam\steamapps\common\Celeste\Celeste.exe</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\Celeste.exe</HintPath>
     </Reference>
     <Reference Include="FNA">
-      <HintPath>..\..\..\..\.steam\steam\steamapps\common\Celeste\FNA.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\FNA.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Celeste">
-      <HintPath>..\..\..\..\.steam\steam\steamapps\common\Celeste\MMHOOK_Celeste.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\MMHOOK_Celeste.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <HintPath>..\..\..\..\.steam\steam\steamapps\common\Celeste\System.dll</HintPath>
@@ -66,8 +63,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="YamlDotNet">
-      <HintPath>..\..\..\..\.steam\steam\steamapps\common\Celeste\YamlDotNet.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/EasyRetry/RetryModule.cs
+++ b/EasyRetry/RetryModule.cs
@@ -46,26 +46,7 @@ namespace Celeste.Mod.EasyRetry
                     }
                     if (Button.Check && !self.Paused)
                     {
-                        var player = self.Tracker.GetEntity<Player>();
-                        if (player != null)
-                        {
-                            if (player != null && !player.Dead && !self.Transitioning && !self.InCutscene && !self.SkippingCutscene && player.CanRetry)
-                            {
-                                Engine.TimeRate = 1f;
-                                Distort.GameRate = 1f;
-                                Distort.Anxiety = 0f;
-
-                                self.InCutscene = (self.SkippingCutscene = false);
-                                player.Die(Vector2.Zero, evenIfInvincible: true);
-                                foreach (LevelEndingHook component in self.Tracker.GetComponents<LevelEndingHook>())
-                                {
-                                    if (component.OnEnd != null)
-                                    {
-                                        component.OnEnd();
-                                    }
-                                }
-                            }
-                        }
+                        Retry(self);
                     }
 
                 }
@@ -73,6 +54,30 @@ namespace Celeste.Mod.EasyRetry
 
                 orig(self);
             };
+        }
+
+        public static void Retry(Level self)
+        {
+            var player = self.Tracker.GetEntity<Player>();
+            if (player != null)
+            {
+                if (!player.Dead && !self.Transitioning && !self.InCutscene && !self.SkippingCutscene && player.CanRetry)
+                {
+                    Engine.TimeRate = 1f;
+                    Distort.GameRate = 1f;
+                    Distort.Anxiety = 0f;
+
+                    self.InCutscene = (self.SkippingCutscene = false);
+                    player.Die(Vector2.Zero, evenIfInvincible: true);
+                    foreach (LevelEndingHook component in self.Tracker.GetComponents<LevelEndingHook>())
+                    {
+                        if (component.OnEnd != null)
+                        {
+                            component.OnEnd();
+                        }
+                    }
+                }
+            }
         }
 
         // Optional, initialize anything after Celeste has initialized itself properly.


### PR DESCRIPTION
This pull request just moves the code that makes the Player retry to its own method.
I'm trying to introduce a code mechanic that revolves around whether or not the end user retries, and I cannot realistically hook into the source function for Retrying, so I made this pull request in the hopes that this can resolve my problem, and it appears to currently